### PR TITLE
Fix: 리스트 뷰 UI 이슈, 제보한 소품샵 status 타입 변경

### DIFF
--- a/apps/soso-web/src/app/home/components/Home/components/ListView/index.tsx
+++ b/apps/soso-web/src/app/home/components/Home/components/ListView/index.tsx
@@ -16,6 +16,7 @@ import { applefindUrl, kakaoFindUrl, naverFindUrl } from '@/shared/utils/findSho
 import { useLocationStore } from '@/shared/store/useLocationStore'
 
 interface ListViewProps {
+  isMapViewMode: boolean
   className?: string
   shopData: ShopType[]
   isWishListView: boolean
@@ -26,6 +27,7 @@ interface ListViewProps {
 }
 
 export default function ListView({
+  isMapViewMode,
   className,
   shopData,
   isWishListView,
@@ -46,11 +48,10 @@ export default function ListView({
   }
 
   useEffect(() => {
-    if (headerRef.current) {
-      const offsetHeight = headerRef.current.offsetHeight
-      setHeaderHeight(offsetHeight)
+    if (!isMapViewMode && headerRef.current) {
+      setHeaderHeight(headerRef.current.offsetHeight)
     }
-  }, [])
+  }, [isMapViewMode])
 
   useEffect(() => {
     const setCurrentLocation = async () => {

--- a/apps/soso-web/src/app/home/components/Home/index.tsx
+++ b/apps/soso-web/src/app/home/components/Home/index.tsx
@@ -74,6 +74,7 @@ export default function HomePage() {
         openCategoryModal={() => setIsOpenCategoryModal(true)}
       />
       <ListView
+        isMapViewMode={isMapViewMode}
         className={!isMapViewMode ? 'block' : 'hidden'}
         shopData={shopData ?? []}
         toggleMapViewMode={toggleMapViewMode}

--- a/apps/soso-web/src/app/my/components/ProductLists/types/index.ts
+++ b/apps/soso-web/src/app/my/components/ProductLists/types/index.ts
@@ -8,15 +8,6 @@ export interface MyWishType {
     id: number
     name: string
     mainImage: null | string
-    // type: number
-    // reportStatus: number
-    // lat: number
-    // lng: number
-    // location: string
-    // region: {
-    //   id: number
-    //   name: string
-    // }
   }
 }
 
@@ -51,7 +42,7 @@ export interface MyShopType {
   type: number
   status: number
   rejectMessage: string | null
-  submitStatus: number
+  submitStatus: MyShopSubmitStatus
   createdAt: string
   shop: {
     id: number
@@ -62,6 +53,25 @@ export interface MyShopType {
     location: string
   }
 }
+
+export const MY_SHOP_SUBMIT_STATUS = {
+  // 최초 제보
+  NEW_SHOP_PENDING: 'new_shop_pending',
+  NEW_SHOP_APPROVED: 'new_shop_approved',
+  NEW_SHOP_REJECTED: 'new_shop_rejected',
+
+  // 운영 정보 수정
+  NEW_OPERATING_PENDING: 'new_operating_pending',
+  NEW_OPERATING_APPROVED: 'new_operating_approved',
+  NEW_OPERATING_REJECTED: 'new_operating_rejected',
+
+  // 판매 정보 수정
+  NEW_PRODUCT_PENDING: 'new_product_pending',
+  NEW_PRODUCT_APPROVED: 'new_product_approved',
+  NEW_PRODUCT_REJECTED: 'new_product_rejected',
+} as const
+
+export type MyShopSubmitStatus = (typeof MY_SHOP_SUBMIT_STATUS)[keyof typeof MY_SHOP_SUBMIT_STATUS]
 
 export interface GetMyShopResponse {
   data: MyShopType[]

--- a/apps/soso-web/src/app/my/shop/components/MyShopStatusBadge/index.tsx
+++ b/apps/soso-web/src/app/my/shop/components/MyShopStatusBadge/index.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { MY_SHOP_SUBMIT_STATUS, MyShopSubmitStatus } from '@/app/my/components/ProductLists/types'
+import clsx from 'clsx'
+
+interface MyShopStatusBadgeProps {
+  submitStatus: MyShopSubmitStatus
+}
+
+const SUBMIT_STATUS_CONTENT: Record<MyShopSubmitStatus, React.ReactNode> = {
+  [MY_SHOP_SUBMIT_STATUS.NEW_SHOP_PENDING]: (
+    <>
+      최초 제보 <br /> 확인 중
+    </>
+  ),
+  [MY_SHOP_SUBMIT_STATUS.NEW_SHOP_APPROVED]: <>최초 제보</>,
+  [MY_SHOP_SUBMIT_STATUS.NEW_SHOP_REJECTED]: (
+    <>
+      최초 제보 <br /> 거절됨
+    </>
+  ),
+
+  [MY_SHOP_SUBMIT_STATUS.NEW_OPERATING_PENDING]: (
+    <>
+      운영 정보 수정 <br /> 확인 중
+    </>
+  ),
+  [MY_SHOP_SUBMIT_STATUS.NEW_OPERATING_APPROVED]: <>운영 정보 수정</>,
+  [MY_SHOP_SUBMIT_STATUS.NEW_OPERATING_REJECTED]: (
+    <>
+      운영 정보 수정 <br /> 거절됨
+    </>
+  ),
+
+  [MY_SHOP_SUBMIT_STATUS.NEW_PRODUCT_PENDING]: (
+    <>
+      판매 정보 수정 <br /> 확인 중
+    </>
+  ),
+  [MY_SHOP_SUBMIT_STATUS.NEW_PRODUCT_APPROVED]: <>판매 정보 수정</>,
+  [MY_SHOP_SUBMIT_STATUS.NEW_PRODUCT_REJECTED]: (
+    <>
+      판매 정보 수정 <br /> 거절됨
+    </>
+  ),
+}
+
+export default function MyShopStatusBadge({ submitStatus }: MyShopStatusBadgeProps) {
+  const isPending =
+    submitStatus === MY_SHOP_SUBMIT_STATUS.NEW_SHOP_PENDING ||
+    submitStatus === MY_SHOP_SUBMIT_STATUS.NEW_OPERATING_PENDING ||
+    submitStatus === MY_SHOP_SUBMIT_STATUS.NEW_PRODUCT_PENDING
+
+  return (
+    <div
+      className={clsx(
+        'block w-86 py-6 font-caption',
+        'rounded-8 text-center',
+        isPending ? 'bg-orange-light text-main' : 'bg-gray-50 text-gray-500'
+      )}
+    >
+      {SUBMIT_STATUS_CONTENT[submitStatus]}
+    </div>
+  )
+}

--- a/apps/soso-web/src/app/my/shop/page.tsx
+++ b/apps/soso-web/src/app/my/shop/page.tsx
@@ -6,12 +6,12 @@ import Header from '@/shared/components/layout/Header'
 import Loading from '@/shared/components/loading/Loading'
 import ShopInfo from '@/shared/components/ui/ShopInfo'
 import { useInView } from 'react-intersection-observer'
-import clsx from 'clsx'
 import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import { useDialog } from '@/shared/context/DialogContext'
 import { useDeleteSubmitShopMutation } from '@/app/my/shop/hooks/useDeleteSubmitShopMutation'
 import { formatStringDate } from '@/shared/utils/formatStringDate'
+import MyShopStatusBadge from './components/MyShopStatusBadge'
 
 export default function MyShopPage() {
   const router = useRouter()
@@ -45,60 +45,6 @@ export default function MyShopPage() {
     })
   }
 
-  const getStatus = (status: number) => {
-    switch (status) {
-      case 0:
-        return (
-          <>
-            최초 제보 <br /> 확인 중
-          </>
-        )
-      case 1:
-        return <>최초 제보</>
-      case 2:
-        return (
-          <>
-            최초 제보 <br />
-            거절됨
-          </>
-        )
-      case 3:
-        return (
-          <>
-            운영 정보 수정 <br />
-            확인 중
-          </>
-        )
-      case 4:
-        return <>운영 정보 수정</>
-      case 5:
-        return (
-          <>
-            운영 정보 수정 <br />
-            거절됨
-          </>
-        )
-      case 6:
-        return (
-          <>
-            판매 정보 수정 <br />
-            확인 중
-          </>
-        )
-      case 7:
-        return <>판매 정보 수정</>
-      case 8:
-        return (
-          <>
-            판매 정보 수정 <br />
-            거절됨
-          </>
-        )
-      default:
-        return <>알 수 없음</>
-    }
-  }
-
   // inView 상태가 변경될 때 다음 페이지 데이터 로드
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage && !isLoading) {
@@ -109,18 +55,11 @@ export default function MyShopPage() {
   // 모든 페이지의 데이터를 하나의 배열로 펼치기
   const allShops = myShopData?.pages.flatMap((page) => page.data) || []
 
-  const getStatusColor = (status: number) => {
-    if (status === 0 || status === 3 || status === 6) {
-      return 'bg-orange-light text-main'
-    }
-    return 'text-gray-500 bg-gray-50'
-  }
-
   return (
     <div>
       <Header title="내가 알린 소품샵" type="back" />
       <Flex direction="col" className="w-full">
-        {allShops?.map((data, index) => (
+        {allShops.map((data, index) => (
           <div key={`shop-${data?.id}-${index}`} className="relative w-full">
             <button
               onClick={() => handleLink(data?.shop.id)}
@@ -128,24 +67,16 @@ export default function MyShopPage() {
               className="flex w-full items-center justify-between border-b border-gray-100 px-16 py-18"
             >
               <ShopInfo
-                name={data?.shop.name}
+                name={data.shop.name}
                 date={formatStringDate(data?.createdAt)}
                 disabled={data?.type === 0}
                 imgUrl={data?.shop.mainImage || ''}
               />
             </button>
             <Flex direction="col" gap={8} className="absolute right-16 top-1/2 -translate-y-1/2">
-              <div
-                className={clsx(
-                  'block w-86 py-6 font-caption',
-                  'rounded-8 text-center',
-                  getStatusColor(data?.submitStatus)
-                )}
-              >
-                {getStatus(data?.submitStatus)}
-              </div>
+              <MyShopStatusBadge submitStatus={data.submitStatus} />
               <button
-                onClick={() => handleOpenDeleteModal(data?.id)}
+                onClick={() => handleOpenDeleteModal(data.id)}
                 className="h-26 w-86 rounded-8 border border-gray-100 text-gray-500 font-caption"
               >
                 삭제


### PR DESCRIPTION
# ✨ Fix: 리스트 뷰 UI 이슈, 제보한 샵 status 타입 변경

## 📝 요약(Summary)
- 리스트 뷰에서 아이템 헤더에 가려지는 이슈 수정
- 제보한 소품샵 상태값 number -> string enum으로 변경 및 컴포넌트 분리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
