### PR TITLE
Fix: 리스트뷰 리스트 가상화, 리스트 뷰 버튼에서 총 소품샵 갯수 삭제

### DIFF
--- a/apps/soso-web/package.json
+++ b/apps/soso-web/package.json
@@ -9,11 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@repo/utils": "*",
     "@amplitude/analytics-browser": "^2.25.4",
     "@hookform/resolvers": "^3.10.0",
     "@repo/tailwind-config": "*",
+    "@repo/utils": "*",
     "@tanstack/react-query": "^5.63.0",
+    "@tanstack/react-virtual": "^3.13.18",
     "@typescript-eslint/parser": "^8.19.1",
     "axios": "^1.7.9",
     "clsx": "^2.1.1",

--- a/apps/soso-web/src/app/home/components/Home/components/ListView/index.tsx
+++ b/apps/soso-web/src/app/home/components/Home/components/ListView/index.tsx
@@ -4,16 +4,12 @@ import SearchIcon from '@/shared/components/icons/SearchIcon'
 import CategoryButton from '../CategoryButton'
 import WishViewButton from '../WishViewButton'
 import { useSearchStore } from '@/shared/store/useSearchStore'
-import Flex from '@/shared/components/layout/Flex'
-import Image from 'next/image'
 import Link from 'next/link'
-import { handleImageError } from '@/shared/utils/handleImageError'
 import { useEffect, useRef, useState } from 'react'
-import { getDistance } from '@/shared/utils/getDistance'
 import { getCurrentLocation } from '@/shared/utils/getCurrentLocation'
-import RoadFindButton from '@/shared/components/button/RoadFindButton'
-import { applefindUrl, kakaoFindUrl, naverFindUrl } from '@/shared/utils/findShop'
 import { useLocationStore } from '@/shared/store/useLocationStore'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import ListViewItem from '../ListViewItem'
 
 interface ListViewProps {
   isMapViewMode: boolean
@@ -39,9 +35,28 @@ export default function ListView({
   const { setPrevShop } = useLocationStore()
   const { setSearchValue } = useSearchStore()
   const headerRef = useRef<HTMLDivElement>(null)
+  const parentRef = useRef<HTMLDivElement>(null)
   const [headerHeight, setHeaderHeight] = useState<number>(122)
   const [currentLat, setCurrentLat] = useState<number | null>(0)
   const [currentLng, setCurrentLng] = useState<number | null>(0)
+  const [scrollElement, setScrollElement] = useState<Element | null>(null)
+
+  useEffect(() => {
+    if (parentRef.current) {
+      const parent = parentRef.current.closest('.overflow-y-auto')
+      if (parent) {
+        setScrollElement(parent)
+      }
+    }
+  }, [])
+
+  const virtualizer = useVirtualizer({
+    count: shopData.length,
+    getScrollElement: () => scrollElement,
+    estimateSize: () => 105,
+    overscan: 5,
+    scrollMargin: headerHeight,
+  })
 
   const handleSavePrevLocation = (lat: number, lng: number, id: number) => {
     setPrevShop({ id, lat, lng })
@@ -69,7 +84,7 @@ export default function ListView({
   }, [])
 
   return (
-    <div className={`${className} h-full`}>
+    <div ref={parentRef} className={className}>
       <div ref={headerRef} className="fixed z-sticky flex w-full max-w-screen flex-col bg-white px-18 pt-16">
         <Link href="/search" onClick={() => setSearchValue('')}>
           <div className="relative h-46 w-full">
@@ -88,41 +103,35 @@ export default function ListView({
         </div>
       </div>
 
-      <div className="h-full" style={{ paddingTop: headerHeight }}>
-        {shopData.map((shop) => (
-          <Link
-            key={`home_list_view_shop_${shop.id}`}
-            href={`/shop/${shop.id}`}
-            onClick={() => handleSavePrevLocation(shop.lat, shop.lng, shop.id)}
-            className="overflow-hidden bg-white"
-          >
-            <Flex align="center" className="border-b border-gray-100 px-18 py-16">
-              <div className="relative h-72 min-w-72 overflow-hidden rounded-8">
-                <Image
-                  src={shop.mainImage || '/images/default_item.svg'}
-                  style={{ objectFit: 'cover' }}
-                  fill
-                  alt=""
-                  onError={handleImageError}
-                />
-              </div>
-
-              <Flex className="flex-1 overflow-x-hidden" align="center">
-                <div className="flex flex-1 flex-col overflow-x-hidden px-8">
-                  <h4 className="mb-6 overflow-hidden text-ellipsis whitespace-nowrap font-title4_semi">{shop.name}</h4>
-                  <p className="text-gray-400 font-body1_m">
-                    {currentLat === 0 ? '-' : getDistance(Number(currentLat), Number(currentLng), shop.lat, shop.lng)}
-                  </p>
-                </div>
-                <RoadFindButton
-                  naverUrl={naverFindUrl(shop.name, shop.lat, shop.lng)}
-                  kakaoUrl={kakaoFindUrl(shop.name, shop.lat, shop.lng)}
-                  appleUrl={applefindUrl(shop.lat, shop.lng)}
-                />
-              </Flex>
-            </Flex>
-          </Link>
-        ))}
+      <div
+        className="relative w-full"
+        style={{
+          height: `${virtualizer.getTotalSize() + headerHeight}px`,
+        }}
+      >
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const shop = shopData[virtualItem.index]
+          return (
+            <div
+              key={virtualItem.key}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: `${virtualItem.size}px`,
+                transform: `translateY(${virtualItem.start}px)`,
+              }}
+            >
+              <ListViewItem
+                shop={shop}
+                currentLat={currentLat}
+                currentLng={currentLng}
+                onClick={handleSavePrevLocation}
+              />
+            </div>
+          )
+        })}
       </div>
 
       <div className="fixed bottom-76 left-1/2 flex w-full -translate-x-1/2 flex-col items-end gap-20 px-16 layout-center">

--- a/apps/soso-web/src/app/home/components/Home/components/ListViewButton/index.tsx
+++ b/apps/soso-web/src/app/home/components/Home/components/ListViewButton/index.tsx
@@ -16,9 +16,6 @@ export default function ListViewButton({ className, totalShopCount, ...props }: 
       )}
       {...props}
     >
-      <div className="fixed -top-4 right-16 flex h-16 w-16 items-center justify-center rounded-full bg-main text-12 text-white">
-        {totalShopCount}
-      </div>
       <ListIcon fill={'#72787f'} width={'24'} height={'24'} />
     </button>
   )

--- a/apps/soso-web/src/app/home/components/Home/components/ListViewItem/index.tsx
+++ b/apps/soso-web/src/app/home/components/Home/components/ListViewItem/index.tsx
@@ -1,0 +1,51 @@
+import { ShopType } from '@/shared/types/shopType'
+import Flex from '@/shared/components/layout/Flex'
+import Image from 'next/image'
+import Link from 'next/link'
+import { handleImageError } from '@/shared/utils/handleImageError'
+import { getDistance } from '@/shared/utils/getDistance'
+import RoadFindButton from '@/shared/components/button/RoadFindButton'
+import { applefindUrl, kakaoFindUrl, naverFindUrl } from '@/shared/utils/findShop'
+
+interface ListViewItemProps {
+  shop: ShopType
+  currentLat: number | null
+  currentLng: number | null
+  onClick: (lat: number, lng: number, id: number) => void
+}
+
+export default function ListViewItem({ shop, currentLat, currentLng, onClick }: ListViewItemProps) {
+  return (
+    <Link
+      href={`/shop/${shop.id}`}
+      onClick={() => onClick(shop.lat, shop.lng, shop.id)}
+      className="overflow-hidden bg-white"
+    >
+      <Flex align="center" className="border-b border-gray-100 px-18 py-16">
+        <div className="relative h-72 min-w-72 overflow-hidden rounded-8">
+          <Image
+            src={shop.mainImage || '/images/default_item.svg'}
+            style={{ objectFit: 'cover' }}
+            fill
+            alt=""
+            onError={handleImageError}
+          />
+        </div>
+
+        <Flex className="flex-1 overflow-x-hidden" align="center">
+          <div className="flex flex-1 flex-col overflow-x-hidden px-8">
+            <h4 className="mb-6 overflow-hidden text-ellipsis whitespace-nowrap font-title4_semi">{shop.name}</h4>
+            <p className="text-gray-400 font-body1_m">
+              {currentLat === 0 ? '-' : getDistance(Number(currentLat), Number(currentLng), shop.lat, shop.lng)}
+            </p>
+          </div>
+          <RoadFindButton
+            naverUrl={naverFindUrl(shop.name, shop.lat, shop.lng)}
+            kakaoUrl={kakaoFindUrl(shop.name, shop.lat, shop.lng)}
+            appleUrl={applefindUrl(shop.lat, shop.lng)}
+          />
+        </Flex>
+      </Flex>
+    </Link>
+  )
+}

--- a/apps/soso-web/src/shared/components/provider/RootLayoutProvider/index.tsx
+++ b/apps/soso-web/src/shared/components/provider/RootLayoutProvider/index.tsx
@@ -46,18 +46,13 @@ export default function RootLayoutProvider({ children }: RootLayoutProviderProps
         <DialogProvider>
           <ToastProvider>
             <AuthComponent />
-            {pathname.includes('/soso-admin') ? (
-              <div>{children}</div>
-            ) : (
-              <div
-                ref={contentRef}
-                className={`m-auto h-screenVh w-full max-w-screen overflow-y-auto pb-60 ${pathname === '/' ? 'pt-0' : 'pt-56'} shadow-md`}
-              >
-                {children}
-                {isNavigation && <BottomNavigation />}
-              </div>
-            )}
-
+            <div
+              ref={contentRef}
+              className={`m-auto h-screenVh w-full max-w-screen overflow-y-auto pb-60 ${pathname === '/' ? 'pt-0' : 'pt-56'} shadow-md`}
+            >
+              {children}
+              {isNavigation && <BottomNavigation />}
+            </div>
             <div id="bottom-modal-root" className=""></div>
             <div id="portal-root" className=""></div>
           </ToastProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -994,10 +994,22 @@
   dependencies:
     "@tanstack/table-core" "8.21.3"
 
+"@tanstack/react-virtual@^3.13.18":
+  version "3.13.18"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.18.tgz#9124ee9f08b2ca3c67ffd508dae3732328983362"
+  integrity sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==
+  dependencies:
+    "@tanstack/virtual-core" "3.13.18"
+
 "@tanstack/table-core@8.21.3":
   version "8.21.3"
   resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
   integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
+
+"@tanstack/virtual-core@3.13.18":
+  version "3.13.18"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.18.tgz#586e3c1fe08547ee6abf87e8fb7c99087b9c47ff"
+  integrity sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg==
 
 "@tootallnate/quickjs-emscripten@^0.23.0":
   version "0.23.0"


### PR DESCRIPTION
# ✨ Fix: 리스트뷰 리스트 가상화, 리스트 뷰 버튼에서 총 소품샵 갯수 삭제

## 📝 요약(Summary)
- `@tanstack/virtual`로 렌더링 되는 리스트 뷰의 아이템의 갯수를 20개 이하로 유지시켜 성능개선
- qa 이슈: 총 소품샵 갯수 삭제 

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어

<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
